### PR TITLE
DB-1368: add site id placeholder back to lando

### DIFF
--- a/template.lando.yml
+++ b/template.lando.yml
@@ -3,6 +3,7 @@ recipe: pantheon
 config:
   framework: drupal9
   site: %SITE_NAME%
+  id: %SITE_UUID%
   xdebug: false
 
 # events:


### PR DESCRIPTION
Reverted this change for now as it would cause install problems. Once we've found a solution for DB-1368 we can merge this back in.